### PR TITLE
Add OAuth dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,18 @@ ChatGPTのcodexの練習
    python -c "import secrets; print(secrets.token_hex(16))"
    ```
 
-   生成した文字列を `FLASK_SECRET` に設定した上でアプリを起動します。
+   生成した文字列を `FLASK_SECRET` に設定します。
 
    ```bash
    export FLASK_SECRET=<生成した文字列>  # Windows の場合は set FLASK_SECRET=<文字列>
+   ```
+
+4. 開発環境で HTTP のまま OAuth2 を利用する場合は、`OAUTHLIB_INSECURE_TRANSPORT=1`
+   を設定してからアプリを起動します。本番運用では HTTPS を使用してください。
+
+   ```bash
+   export OAUTHLIB_INSECURE_TRANSPORT=1  # Windows の場合は set OAUTHLIB_INSECURE_TRANSPORT=1
    python app.py
    ```
-4. ブラウザで `http://localhost:5000` にアクセスし、指示に従ってGoogleアカウントを認証します。期間を入力して「Start Classification」を押すと `static/result.csv` が生成され、ダウンロードが始まります。
+
+5. ブラウザで `http://localhost:5000` にアクセスし、指示に従ってGoogleアカウントを認証します。期間を入力して「Start Classification」を押すと `static/result.csv` が生成され、ダウンロードが始まります。

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ from googleapiclient.discovery import build
 import pandas as pd
 from datetime import datetime
 
+# Allow OAuth over HTTP when running locally. Remove or change for production.
+os.environ.setdefault("OAUTHLIB_INSECURE_TRANSPORT", "1")
+
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET", "dev")
 SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]


### PR DESCRIPTION
## Summary
- document how to enable OAuth over HTTP for development
- set `OAUTHLIB_INSECURE_TRANSPORT` automatically in the app

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fba3104fc83298b06e5b7e5b72d19