### PR TITLE
Integrate Gemini classification and Japanese UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ ChatGPTのcodexの練習
    ```bash
    pip install -r requirements.txt
    ```
+   `google-generativeai` も requirements.txt に含まれているため、Gemini API を利用する場合は API キーを別途用意してください。
 3. アプリのセッション情報を保護するため、Flask がセッション署名に利用する秘密鍵を
    環境変数 `FLASK_SECRET` に設定します。以下のワンライナーで 16 バイトのランダム
    文字列を生成できます。
@@ -36,7 +37,7 @@ ChatGPTのcodexの練習
    python app.py
    ```
 
-5. ブラウザで `http://localhost:5000` にアクセスし、指示に従ってGoogleアカウントを認証します。期間を入力して「Start Classification」を押すと `static/result.csv` が生成され、ダウンロードが始まります。
+5. ブラウザで `http://localhost:5000` にアクセスし、指示に従ってGoogleアカウントを認証します。Gemini API キーと期間を入力して「分類を開始」を押すと `static/result.csv` が生成され、ダウンロードが始まります。
 
 ### OAuth のスコープエラーが出る場合
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 google-auth
 google-auth-oauthlib
 google-api-python-client
+google-generativeai

--- a/templates/classify.html
+++ b/templates/classify.html
@@ -1,18 +1,22 @@
 <!doctype html>
 <html>
 <head>
-  <title>Choose Date Range</title>
+  <meta charset="utf-8">
+  <title>期間指定</title>
 </head>
 <body>
-  <h1>Select Date Range</h1>
+  <h1>期間を指定してください</h1>
   <form method="POST">
-    <label>Start Date (YYYY/MM/DD):<br>
+    <label>Gemini APIキー:<br>
+      <input type="password" name="gemini_key" required>
+    </label><br>
+    <label>開始日 (YYYY/MM/DD):<br>
       <input type="text" name="start_date" required>
     </label><br>
-    <label>End Date (YYYY/MM/DD):<br>
+    <label>終了日 (YYYY/MM/DD):<br>
       <input type="text" name="end_date">
     </label><br>
-    <button type="submit">Start Classification</button>
+    <button type="submit">分類を開始</button>
   </form>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,14 @@
 <!doctype html>
 <html>
 <head>
-  <title>Gmail Classification</title>
+  <meta charset="utf-8">
+  <title>Gmail分類アプリ</title>
 </head>
 <body>
-  <h1>Gmail Classification App</h1>
-  <p>Start by authorizing your Gmail account.</p>
-  <a href="{{ url_for('authorize') }}">Authorize Gmail</a>
+  <h1>Gmail分類アプリ</h1>
+  <p>まず、Gmailへのアクセスを許可してください。</p>
+  <a href="{{ url_for('authorize') }}">Gmailを認証する</a>
   <br>
-  <a href="{{ url_for('reset_credentials') }}">Reset saved credentials</a>
+  <a href="{{ url_for('reset_credentials') }}">保存された認証情報を削除</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `google-generativeai` dependency
- translate templates to Japanese and add Gemini API key field
- call Gemini API to classify email subject and body
- save Gemini analysis to CSV
- document the new workflow in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683fd1f110d4832986d189ed4a81e568